### PR TITLE
Use busybox, debian seems overkill for sleep

### DIFF
--- a/sleep/Dockerfile
+++ b/sleep/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM busybox:latest
 
 LABEL "maintainer"="maddox <jon@jonmaddox.com>"
 LABEL "repository"="https://github.com/maddox/actions"


### PR DESCRIPTION
https://www.brianchristner.io/docker-image-base-os-size-comparison/

Tested locally, `sleep` is supported in `busybox:latest`. Don't have actions setup yet (signed up for beta) so can't test there.