### PR TITLE
ssh: Add support for a custom port

### DIFF
--- a/ssh/README.md
+++ b/ssh/README.md
@@ -41,6 +41,10 @@ You'll need to provide some secrets to use the action.
 * **HOST**: The host the action will SSH to to run the command. ie, `your.site.com`.
 * **USER**: The user the SSH command will auth as with the public key.
 
+### Optional Secrets
+
+* **PORT**: The port SSH is listening on. Default: `22`
+
 ## License
 
 The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/ssh/entrypoint.sh
+++ b/ssh/entrypoint.sh
@@ -20,4 +20,4 @@ ssh-add "$SSH_PATH/deploy_key"
 
 ssh-keyscan -t rsa $HOST >> "$SSH_PATH/known_hosts"
 
-ssh -A -tt -o 'StrictHostKeyChecking=no' $USER@$HOST "$*"
+ssh -A -tt -o 'StrictHostKeyChecking=no' -p ${PORT:-22} $USER@$HOST "$*"


### PR DESCRIPTION
Thanks for the action!

This adds support for defining a custom SSH port. If `PORT` is not defined, we fall back to `22`.

Tested the action in my repo using the fallback port and defining a custom one via a secret, both worked for me!