### PR TITLE
Fix error caused by existing .ssh directory

### DIFF
--- a/ssh/entrypoint.sh
+++ b/ssh/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 SSH_PATH="$HOME/.ssh"
 
-mkdir "$SSH_PATH"
+mkdir -p "$SSH_PATH"
 touch "$SSH_PATH/known_hosts"
 
 echo "$PRIVATE_KEY" > "$SSH_PATH/deploy_key"


### PR DESCRIPTION
I've encountered a problem in the `ssh` action. If it runs more than once the .ssh directory created
during the first run persists to subsequent runs and causes an error in `mkdir` commands.

I've added the `-p` flag which will cause it to simply skip that directory if it already exists 😄 