### PR TITLE
Remove public key requirement from ssh action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ action "Run deploy script" {
   args = "/opt/deploy/run"
   secrets = [
     "PRIVATE_KEY",
-    "PUBLIC_KEY",
     "HOST",
     "USER"
   ]

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -16,7 +16,6 @@ action "Run deploy script" {
   args = "/opt/deploy/run"
   secrets = [
     "PRIVATE_KEY",
-    "PUBLIC_KEY",
     "HOST",
     "USER"
   ]
@@ -37,9 +36,8 @@ The argument you will use is the command that will be ran on your server via SSH
 You'll need to provide some secrets to use the action.
 
 * **PRIVATE_KEY**: Your SSH private key.
-* **PUBLIC_KEY**: Your SSH public key.
 * **HOST**: The host the action will SSH to to run the command. ie, `your.site.com`.
-* **USER**: The user the SSH command will auth as with the public key.
+* **USER**: The user the SSH command will auth as with the private key.
 
 ### Optional Secrets
 

--- a/ssh/entrypoint.sh
+++ b/ssh/entrypoint.sh
@@ -8,16 +8,14 @@ mkdir "$SSH_PATH"
 touch "$SSH_PATH/known_hosts"
 
 echo "$PRIVATE_KEY" > "$SSH_PATH/deploy_key"
-echo "$PUBLIC_KEY" > "$SSH_PATH/deploy_key.pub"
 
 chmod 700 "$SSH_PATH"
 chmod 600 "$SSH_PATH/known_hosts"
 chmod 600 "$SSH_PATH/deploy_key"
-chmod 600 "$SSH_PATH/deploy_key.pub"
 
 eval $(ssh-agent)
 ssh-add "$SSH_PATH/deploy_key"
 
 ssh-keyscan -t rsa $HOST >> "$SSH_PATH/known_hosts"
 
-ssh -A -tt -o 'StrictHostKeyChecking=no' -p ${PORT:-22} $USER@$HOST "$*"
+ssh -o StrictHostKeyChecking=no -A -tt -p ${PORT:-22} $USER@$HOST "$*"


### PR DESCRIPTION
As far as I know public key is not needed in the `ssh` action, so I removed it. I'm not an SSH expert though, so if there's some use case which requires a public key just let me know 😀 

If you merge it I will follow with another PR with updated images.