### PR TITLE
Implement SCP action

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ action "Run deploy script" {
 }
 ```
 
+# [SCP](scp)
+
+This action will copy the provided file to your $HOST via SCP.
+
+```
+action "Copy build artifact" {
+  uses = "maddox/actions/scp@master"
+  args = "./your-file"
+  secrets = [
+    "PRIVATE_KEY",
+    "HOST",
+    "USER",
+    "TARGET"
+  ]
+}
+```
+
 ## [Sleep](sleep)
 
 This action will simply call `sleep` for N seconds in case you need a little

--- a/scp/Dockerfile
+++ b/scp/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:stable-slim
+
+LABEL "maintainer"="maddox <jon@jonmaddox.com>"
+LABEL "repository"="https://github.com/maddox/actions"
+LABEL "version"="1.0.1"
+
+LABEL "com.github.actions.name"="SCP"
+LABEL "com.github.actions.description"="Copy file via SCP"
+LABEL "com.github.actions.icon"="copy"
+LABEL "com.github.actions.color"="orange"
+
+RUN apt-get update && apt-get install -y \
+  openssh-client && \
+  rm -Rf /var/lib/apt/lists/*
+
+
+ADD entrypoint.sh /entrypoint.sh
+
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/scp/LICENSE
+++ b/scp/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 GitHub, Inc. and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/scp/README.md
+++ b/scp/README.md
@@ -1,0 +1,48 @@
+# SCP for GitHub Actions
+
+Copy a thing on your server.
+
+This action will copy the provided file to your $HOST via SCP.
+
+## Usage
+
+To use the action simply add the following lines to your `.github/main.workflow`
+
+```
+action "Copy build artifact" {
+  uses = "maddox/actions/scp@master"
+  args = "./your-file"
+  secrets = [
+    "PRIVATE_KEY",
+    "HOST",
+    "USER",
+    "TARGET"
+  ]
+}
+```
+
+### Required Arguments
+
+The argument you will use is the file that will be copied to your server via SCP.
+
+#### Examples
+
+* ```args = "./dist.tar"```
+* ```args = "/var/build/output.zip"```
+
+### Required Secrets
+
+You'll need to provide some secrets to use the action.
+
+* **PRIVATE_KEY**: Your SSH private key.
+* **HOST**: The host the action will SCP to to copy the file. ie, `your.site.com`.
+* **USER**: The user the SCP command will auth as with the private key.
+* **TARGET**: The path to the target directory on the host.
+
+### Optional Secrets
+
+* **PORT**: The port SSH is listening on. Default: `22`
+
+## License
+
+The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/scp/entrypoint.sh
+++ b/scp/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+SSH_PATH="$HOME/.ssh"
+
+mkdir -p "$SSH_PATH"
+touch "$SSH_PATH/known_hosts"
+
+echo "$PRIVATE_KEY" > "$SSH_PATH/deploy_key"
+
+chmod 700 "$SSH_PATH"
+chmod 600 "$SSH_PATH/known_hosts"
+chmod 600 "$SSH_PATH/deploy_key"
+
+eval $(ssh-agent)
+ssh-add "$SSH_PATH/deploy_key"
+
+ssh-keyscan -t rsa $HOST >> "$SSH_PATH/known_hosts"
+
+scp -o StrictHostKeyChecking=no -P ${PORT:-22} $* $USER@$HOST:$TARGET


### PR DESCRIPTION
Since installing `openssh-client` will give access to the SCP program, I copied the `ssh` action and just changed the command in the entrypoint.

If you merge it I will follow with a PR with images.