### PR TITLE
Fix debian issue Error: Docker build failed with exit code 100

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 LABEL "maintainer"="maddox <jon@jonmaddox.com>"
 LABEL "repository"="https://github.com/maddox/actions"
-LABEL "version"="1.0.1"
+LABEL "version"="1.0.2"
 
 LABEL "com.github.actions.name"="SSH"
 LABEL "com.github.actions.description"="Run command via SSH"


### PR DESCRIPTION
reportedly the current image needs a rebuild (https://github.com/debuerreotype/docker-debian-artifacts/issues/134). This problem seems to be related to that the tags stable/stable-slim are built at 20210721 and still Buster (Debian 10) versions.
To try to fix this i changed the docker image for debian:bullseye-slim. Could you evaluate and see if this makes sense to you? @maddox 
related: https://github.com/maddox/actions/issues/19
thanksss.